### PR TITLE
feat: Implement initial Blade views for Admin and User Dashboards

### DIFF
--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Valve;
+use App\Models\Schedule;
+use App\Models\User;
+use App\Models\OperationLog;
+use Carbon\Carbon;
+
+class DashboardController extends Controller
+{
+    public function index()
+    {
+        $totalValves = Valve::count();
+        $activeSchedules = Schedule::where('is_enabled', true)->count();
+        $totalUsers = User::count();
+
+        $valvesStatus = Valve::orderBy('valve_number')->get(['valve_number', 'name', 'current_state', 'last_activated_at']);
+
+        // Próximos agendamentos (exemplo simples para os próximos 7 dias)
+        // Esta lógica pode ser mais complexa para calcular a próxima execução real de cada agendamento
+        $upcomingSchedules = Schedule::where('is_enabled', true)
+            // ->where('day_of_week', '>=', Carbon::now()->dayOfWeek) // Simplificação, precisa de lógica mais robusta
+            ->orderBy('day_of_week')
+            ->orderBy('start_time')
+            ->take(5)
+            ->get();
+
+        // Lógica mais precisa para próximos agendamentos
+        $nextOccurrences = [];
+        $schedules = Schedule::where('is_enabled', true)->get();
+        $today = Carbon::now();
+
+        foreach ($schedules as $schedule) {
+            $scheduleTime = Carbon::createFromTimeString($schedule->start_time);
+            for ($i = 0; $i < 7; $i++) { // Verificar nos próximos 7 dias
+                $checkDay = $today->copy()->addDays($i);
+                if ($checkDay->dayOfWeek == $schedule->day_of_week) {
+                    $occurrence = $checkDay->setTime($scheduleTime->hour, $scheduleTime->minute, $scheduleTime->second);
+                    if ($occurrence->isFuture()) {
+                        $nextOccurrences[] = [
+                            'name' => $schedule->name,
+                            'datetime' => $occurrence,
+                            'original_schedule' => $schedule // Para links ou mais detalhes
+                        ];
+                        break; // Pegar apenas a próxima ocorrência deste agendamento
+                    }
+                }
+            }
+        }
+        // Ordenar as ocorrências e pegar as primeiras 5
+        usort($nextOccurrences, function ($a, $b) {
+            return $a['datetime'] <=> $b['datetime'];
+        });
+        $upcomingSchedulesProcessed = array_slice($nextOccurrences, 0, 5);
+
+
+        $recentErrorLogs = OperationLog::whereIn('status', ['ERROR', 'CRITICAL'])
+            ->orderBy('logged_at', 'desc')
+            ->take(5)
+            ->get();
+
+        $recentSystemLogs = OperationLog::orderBy('logged_at', 'desc')
+            ->take(5)
+            ->get();
+
+        return view('admin.dashboard', compact(
+            'totalValves',
+            'activeSchedules',
+            'totalUsers',
+            'valvesStatus',
+            'upcomingSchedulesProcessed', // Usar esta variável processada
+            'recentErrorLogs',
+            'recentSystemLogs'
+        ));
+    }
+}

--- a/app/Http/Controllers/UserDashboardController.php
+++ b/app/Http/Controllers/UserDashboardController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Valve;
+use App\Models\Schedule;
+use App\Models\OperationLog;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class UserDashboardController extends Controller
+{
+    /**
+     * Display the user dashboard.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function index()
+    {
+        // Se o utilizador for admin, redirecionar para o dashboard de admin
+        if (Auth::user()->hasRole('admin')) {
+            return redirect()->route('admin.dashboard'); // Assumindo que esta rota existe e está nomeada
+        }
+
+        $valvesStatus = Valve::orderBy('valve_number')->get(['valve_number', 'name', 'current_state', 'last_activated_at']);
+
+        // Próximos agendamentos (lógica similar ao AdminDashboardController)
+        $nextOccurrences = [];
+        $schedules = Schedule::where('is_enabled', true)->get();
+        $today = Carbon::now();
+
+        foreach ($schedules as $schedule) {
+            $scheduleTime = Carbon::createFromTimeString($schedule->start_time);
+            for ($i = 0; $i < 7; $i++) { // Verificar nos próximos 7 dias
+                $checkDay = $today->copy()->addDays($i);
+                if ($checkDay->dayOfWeek == $schedule->day_of_week) {
+                    $occurrence = $checkDay->setTime($scheduleTime->hour, $scheduleTime->minute, $scheduleTime->second);
+                    if ($occurrence->isFuture()) {
+                        $nextOccurrences[] = [
+                            'name' => $schedule->name,
+                            'datetime' => $occurrence,
+                            'per_valve_duration_minutes' => $schedule->per_valve_duration_minutes
+                        ];
+                        break;
+                    }
+                }
+            }
+        }
+        usort($nextOccurrences, function ($a, $b) {
+            return $a['datetime'] <=> $b['datetime'];
+        });
+        $upcomingSchedulesProcessed = array_slice($nextOccurrences, 0, 3); // Mostrar apenas os próximos 3
+
+        // Últimos logs de operação gerais (INFO ou SUCCESS)
+        $recentSystemLogs = OperationLog::whereIn('status', ['INFO', 'SUCCESS'])
+            ->where(function ($query) { // Logs de sistema ou de agendamentos
+                $query->where('source', 'SYSTEM')
+                      ->orWhere('source', 'SCHEDULED_TASK')
+                      ->orWhere('event_type', 'LIKE', '%CYCLE%'); // Logs relacionados a ciclos
+            })
+            ->orderBy('logged_at', 'desc')
+            ->take(5)
+            ->get();
+
+        return view('dashboard', compact(
+            'valvesStatus',
+            'upcomingSchedulesProcessed',
+            'recentSystemLogs'
+        ));
+    }
+}

--- a/app/View/Components/Admin/StatCard.php
+++ b/app/View/Components/Admin/StatCard.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\View\Components\Admin;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class StatCard extends Component
+{
+    public string $title;
+    public string $value;
+    public string $iconClass; // Ex: 'text-blue-500'
+    public string $iconPath;  // SVG path data
+
+    /**
+     * Create a new component instance.
+     *
+     * @param string $title
+     * @param string $value
+     * @param string $iconClass
+     * @param string $iconPath
+     */
+    public function __construct(string $title, string $value, string $iconPath, string $iconClass = 'text-gray-500')
+    {
+        $this->title = $title;
+        $this->value = $value;
+        $this->iconPath = $iconPath;
+        $this->iconClass = $iconClass;
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View|Closure|string
+    {
+        return view('components.admin.stat-card');
+    }
+}

--- a/app/View/Components/SessionAlert.php
+++ b/app/View/Components/SessionAlert.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class SessionAlert extends Component
+{
+    public ?string $successMessage;
+    public ?string $errorMessage;
+
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->successMessage = session('success');
+        $this->errorMessage = session('error');
+    }
+
+    /**
+     * Determine if the component should render.
+     *
+     * @return bool
+     */
+    public function shouldRender(): bool
+    {
+        return !empty($this->successMessage) || !empty($this->errorMessage);
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View|Closure|string
+    {
+        return view('components.session-alert');
+    }
+}

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,0 +1,156 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Dashboard de Administração') }}
+        </h2>
+    </x-slot>
+
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <!-- Cartões de Sumário -->
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
+            <div class="bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6">
+                <div class="flex items-center">
+                    {{-- <x-heroicon-o-cpu-chip class="h-8 w-8 text-blue-500"/> --}}
+                    <svg class="h-8 w-8 text-blue-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M5.25 5.25a3 3 0 00-3 3v10.5a3 3 0 003 3h10.5a3 3 0 003-3V13.5a.75.75 0 00-1.5 0v5.25a1.5 1.5 0 01-1.5 1.5H5.25a1.5 1.5 0 01-1.5-1.5V8.25a1.5 1.5 0 011.5-1.5h5.25a.75.75 0 000-1.5H5.25z" /><path stroke-linecap="round" stroke-linejoin="round" d="M10.5 6a.75.75 0 001.13-.65l.75-3.75a.75.75 0 00-.641-.862l-3.75-.75a.75.75 0 00-.862.64L6.35 2.87a.75.75 0 00.65 1.13l3.5 1.25zM12.75 6h1.5a.75.75 0 000-1.5h-1.5a.75.75 0 000 1.5zM10.5 8.25h5.25a.75.75 0 000-1.5H10.5a.75.75 0 000 1.5zM10.5 10.5h5.25a.75.75 0 000-1.5H10.5a.75.75 0 000 1.5zM10.5 12.75h5.25a.75.75 0 000-1.5H10.5a.75.75 0 000 1.5zM15 15.75a.75.75 0 00.75-.75v-1.5a.75.75 0 00-1.5 0v1.5a.75.75 0 00.75.75z" /></svg>
+
+                    <div class="ml-4">
+                        <p class="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase">Total de Válvulas</p>
+                        <p class="text-2xl font-semibold text-gray-900 dark:text-gray-100">{{ $totalValves }}</p>
+                    </div>
+                </div>
+            </div>
+            <div class="bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6">
+                <div class="flex items-center">
+                    {{-- <x-heroicon-o-clock class="h-8 w-8 text-green-500"/> --}}
+                    <svg class="h-8 w-8 text-green-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                    <div class="ml-4">
+                        <p class="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase">Agendamentos Ativos</p>
+                        <p class="text-2xl font-semibold text-gray-900 dark:text-gray-100">{{ $activeSchedules }}</p>
+                    </div>
+                </div>
+            </div>
+            <div class="bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6">
+                <div class="flex items-center">
+                    {{-- <x-heroicon-o-users class="h-8 w-8 text-purple-500"/> --}}
+                    <svg class="h-8 w-8 text-purple-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z" /></svg>
+                    <div class="ml-4">
+                        <p class="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase">Total de Utilizadores</p>
+                        <p class="text-2xl font-semibold text-gray-900 dark:text-gray-100">{{ $totalUsers }}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <!-- Estado Atual das Válvulas -->
+            <div class="bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6">
+                <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Estado Atual das Válvulas</h3>
+                <div class="space-y-3">
+                    @forelse ($valvesStatus as $valve)
+                        <div class="flex justify-between items-center p-3 bg-gray-50 dark:bg-gray-700 rounded-md">
+                            <div>
+                                <span class="font-medium text-gray-800 dark:text-gray-200">Válvula {{ $valve->valve_number }}: {{ $valve->name }}</span>
+                                <p class="text-xs text-gray-500 dark:text-gray-400">Última ativação: {{ $valve->last_activated_at ? \Carbon\Carbon::parse($valve->last_activated_at)->diffForHumans() : 'N/A' }}</p>
+                            </div>
+                            <span class="px-3 py-1 text-xs font-semibold rounded-full
+                                {{ $valve->current_state ? 'bg-green-200 text-green-800' : 'bg-red-200 text-red-800' }}">
+                                {{ $valve->current_state ? 'Ligada' : 'Desligada' }}
+                            </span>
+                        </div>
+                    @empty
+                        <p class="text-gray-500 dark:text-gray-400">Nenhuma válvula configurada.</p>
+                    @endforelse
+                </div>
+                 <div class="mt-4 text-right">
+                    <a href="{{ route('admin.valves.index') }}" class="text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline">Gerir Válvulas &rarr;</a>
+                </div>
+            </div>
+
+            <!-- Próximos Agendamentos -->
+            <div class="bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6">
+                @php $daysOfWeek = ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb']; @endphp
+                <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Próximos Agendamentos (Próximos 7 dias)</h3>
+                <div class="space-y-3">
+                    @forelse ($upcomingSchedulesProcessed as $occurrence)
+                        <div class="p-3 bg-gray-50 dark:bg-gray-700 rounded-md">
+                            <p class="font-medium text-gray-800 dark:text-gray-200">{{ $occurrence['name'] }}</p>
+                            <p class="text-sm text-gray-600 dark:text-gray-300">
+                                {{ $daysOfWeek[$occurrence['datetime']->dayOfWeek] }}, {{ $occurrence['datetime']->format('d/m/Y H:i') }}
+                                (Duração/Válvula: {{ $occurrence['original_schedule']->per_valve_duration_minutes }} min)
+                            </p>
+                        </div>
+                    @empty
+                        <p class="text-gray-500 dark:text-gray-400">Nenhum agendamento ativo encontrado para os próximos dias.</p>
+                    @endforelse
+                </div>
+                <div class="mt-4 text-right">
+                    <a href="{{ route('admin.schedules.index') }}" class="text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline">Gerir Agendamentos &rarr;</a>
+                </div>
+            </div>
+        </div>
+
+        <!-- Logs Recentes -->
+        <div class="mt-6 grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <div class="bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6">
+                <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Últimos Logs de Erro/Críticos</h3>
+                @if($recentErrorLogs->isEmpty())
+                    <p class="text-sm text-gray-500 dark:text-gray-400">Nenhum log de erro recente.</p>
+                @else
+                    <ul class="space-y-2">
+                        @foreach($recentErrorLogs as $log)
+                        <li class="text-sm p-2 rounded {{ $log->status === 'CRITICAL' ? 'bg-pink-100 dark:bg-pink-900 text-pink-700 dark:text-pink-300' : 'bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300' }}">
+                            <a href="{{ route('admin.operation-logs.show', $log) }}" class="hover:underline">
+                                <strong class="font-medium">{{ \Carbon\Carbon::parse($log->logged_at)->format('d/m H:i') }} [{{$log->source}}]:</strong> {{ Str::limit($log->message, 60) }}
+                            </a>
+                        </li>
+                        @endforeach
+                    </ul>
+                @endif
+                <div class="mt-4 text-right">
+                    <a href="{{ route('admin.operation-logs.index', ['status' => 'ERROR']) }}" class="text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline">Ver todos os logs de erro &rarr;</a>
+                </div>
+            </div>
+            <div class="bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6">
+                <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Últimos Logs do Sistema</h3>
+                 @if($recentSystemLogs->isEmpty())
+                    <p class="text-sm text-gray-500 dark:text-gray-400">Nenhum log recente.</p>
+                @else
+                    <ul class="space-y-2">
+                        @foreach($recentSystemLogs as $log)
+                        <li class="text-sm p-2 rounded bg-gray-50 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
+                            <a href="{{ route('admin.operation-logs.show', $log) }}" class="hover:underline">
+                                <strong class="font-medium">{{ \Carbon\Carbon::parse($log->logged_at)->format('d/m H:i') }} [{{$log->source}} - {{$log->status}}]:</strong> {{ Str::limit($log->message, 60) }}
+                            </a>
+                        </li>
+                        @endforeach
+                    </ul>
+                @endif
+                <div class="mt-4 text-right">
+                    <a href="{{ route('admin.operation-logs.index') }}" class="text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline">Ver todos os logs &rarr;</a>
+                </div>
+            </div>
+        </div>
+         <!-- Links Rápidos Adicionais -->
+        <div class="mt-6 bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6">
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Acesso Rápido</h3>
+            <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                <a href="{{ route('admin.valves.index') }}" class="block p-4 bg-blue-500 hover:bg-blue-600 text-white rounded-lg text-center font-medium transition-colors">
+                    Gerir Válvulas
+                </a>
+                <a href="{{ route('admin.schedules.index') }}" class="block p-4 bg-green-500 hover:bg-green-600 text-white rounded-lg text-center font-medium transition-colors">
+                    Gerir Agendamentos
+                </a>
+                <a href="{{ route('admin.users.index') }}" class="block p-4 bg-purple-500 hover:bg-purple-600 text-white rounded-lg text-center font-medium transition-colors">
+                    Gerir Utilizadores
+                </a>
+                <a href="{{ route('admin.telegram-users.index') }}" class="block p-4 bg-sky-500 hover:bg-sky-600 text-white rounded-lg text-center font-medium transition-colors">
+                    Utilizadores Telegram
+                </a>
+                 <a href="{{ route('admin.operation-logs.index') }}" class="block p-4 bg-gray-500 hover:bg-gray-600 text-white rounded-lg text-center font-medium transition-colors">
+                    Ver Logs
+                </a>
+                {{-- Adicionar mais links conforme necessário --}}
+            </div>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/operation_logs/index.blade.php
+++ b/resources/views/admin/operation_logs/index.blade.php
@@ -1,0 +1,130 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Logs de Operação do Sistema') }}
+        </h2>
+    </x-slot>
+
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+
+        {{-- Área de Filtros (Placeholder - pode ser implementada depois) --}}
+        {{--
+        <div class="mb-6 p-4 bg-white dark:bg-gray-800 shadow-md rounded-lg">
+            <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">{{ __('Filtros') }}</h3>
+            <form action="{{ route('admin.operation-logs.index') }}" method="GET" class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                <div>
+                    <label for="event_type" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Tipo de Evento') }}</label>
+                    <input type="text" name="event_type" id="event_type" value="{{ request('event_type') }}" class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm dark:bg-gray-700 dark:text-gray-200">
+                </div>
+                <div>
+                    <label for="source" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Origem') }}</label>
+                    <select name="source" id="source" class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm dark:bg-gray-700 dark:text-gray-200">
+                        <option value="">{{ __('Todos') }}</option>
+                        <option value="SYSTEM" {{ request('source') == 'SYSTEM' ? 'selected' : '' }}>{{ __('Sistema') }}</option>
+                        <option value="ESP32" {{ request('source') == 'ESP32' ? 'selected' : '' }}>{{ __('ESP32') }}</option>
+                        <option value="WEB_PORTAL" {{ request('source') == 'WEB_PORTAL' ? 'selected' : '' }}>{{ __('Portal Web') }}</option>
+                        <option value="TELEGRAM_BOT" {{ request('source') == 'TELEGRAM_BOT' ? 'selected' : '' }}>{{ __('Bot Telegram') }}</option>
+                        <option value="SCHEDULED_TASK" {{ request('source') == 'SCHEDULED_TASK' ? 'selected' : '' }}>{{ __('Tarefa Agendada') }}</option>
+                    </select>
+                </div>
+                <div>
+                    <label for="status" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Status') }}</label>
+                     <select name="status" id="status" class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm dark:bg-gray-700 dark:text-gray-200">
+                        <option value="">{{ __('Todos') }}</option>
+                        <option value="SUCCESS" {{ request('status') == 'SUCCESS' ? 'selected' : '' }}>{{ __('Sucesso') }}</option>
+                        <option value="INFO" {{ request('status') == 'INFO' ? 'selected' : '' }}>{{ __('Info') }}</option>
+                        <option value="WARNING" {{ request('status') == 'WARNING' ? 'selected' : '' }}>{{ __('Aviso') }}</option>
+                        <option value="ERROR" {{ request('status') == 'ERROR' ? 'selected' : '' }}>{{ __('Erro') }}</option>
+                        <option value="CRITICAL" {{ request('status') == 'CRITICAL' ? 'selected' : '' }}>{{ __('Crítico') }}</option>
+                    </select>
+                </div>
+                <div class="flex items-end">
+                    <button type="submit" class="inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-500">
+                        {{ __('Filtrar') }}
+                    </button>
+                    <a href="{{ route('admin.operation-logs.index') }}" class="ml-2 inline-flex items-center px-4 py-2 bg-gray-300 border border-transparent rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-gray-400">
+                        {{ __('Limpar') }}
+                    </a>
+                </div>
+            </form>
+        </div>
+        --}}
+
+        @if (session('success'))
+            <div class="mb-4 p-4 bg-green-100 text-green-700 border border-green-300 rounded-md">
+                {{ session('success') }}
+            </div>
+        @endif
+
+        <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg overflow-hidden">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <thead class="bg-gray-50 dark:bg-gray-700">
+                    <tr>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Data/Hora') }}
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Tipo de Evento') }}
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Mensagem') }}
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Origem') }}
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Status') }}
+                        </th>
+                        <th scope="col" class="relative px-6 py-3">
+                            <span class="sr-only">{{ __('Ações') }}</span>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                    @forelse ($logs as $log)
+                        <tr>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                {{ \Carbon\Carbon::parse($log->logged_at)->format('d/m/Y H:i:s') }}
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">
+                                {{ $log->event_type }}
+                            </td>
+                            <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-300 truncate max-w-xs">
+                                {{ Str::limit($log->message, 70) }}
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                {{ $log->source }}
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm">
+                                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full
+                                    @switch($log->status)
+                                        @case('SUCCESS') bg-green-100 text-green-800 @break
+                                        @case('INFO') bg-blue-100 text-blue-800 @break
+                                        @case('WARNING') bg-yellow-100 text-yellow-800 @break
+                                        @case('ERROR') bg-red-100 text-red-800 @break
+                                        @case('CRITICAL') bg-pink-100 text-pink-800 @break
+                                        @default bg-gray-100 text-gray-800 @break
+                                    @endswitch
+                                ">
+                                    {{ $log->status }}
+                                </span>
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                <a href="{{ route('admin.operation-logs.show', $log) }}" class="text-blue-600 hover:text-blue-900 dark:text-blue-400 dark:hover:text-blue-200">{{ __('Ver Detalhes') }}</a>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="6" class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300 text-center">
+                                {{ __('Nenhum log de operação encontrado.') }}
+                            </td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+        <div class="mt-4">
+            {{ $logs->appends(request()->query())->links() }} {{-- Manter filtros na paginação --}}
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/operation_logs/show.blade.php
+++ b/resources/views/admin/operation_logs/show.blade.php
@@ -1,0 +1,113 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Detalhes do Log de Operação') }} #{{ $log->id }}
+        </h2>
+    </x-slot>
+
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-6">
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                <div class="md:col-span-1">
+                    <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">{{ __('Informações Gerais') }}</h3>
+                    <dl class="mt-2 divide-y divide-gray-200 dark:divide-gray-700">
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('ID do Log') }}</dt>
+                            <dd class="text-gray-900 dark:text-gray-100">{{ $log->id }}</dd>
+                        </div>
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('Data/Hora') }}</dt>
+                            <dd class="text-gray-900 dark:text-gray-100">{{ \Carbon\Carbon::parse($log->logged_at)->format('d/m/Y H:i:s') }} ({{ \Carbon\Carbon::parse($log->logged_at)->diffForHumans() }})</dd>
+                        </div>
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('Tipo de Evento') }}</dt>
+                            <dd class="text-gray-900 dark:text-gray-100">{{ $log->event_type }}</dd>
+                        </div>
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('Origem') }}</dt>
+                            <dd class="text-gray-900 dark:text-gray-100">{{ $log->source }}</dd>
+                        </div>
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('Status') }}</dt>
+                            <dd>
+                                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full
+                                    @switch($log->status)
+                                        @case('SUCCESS') bg-green-100 text-green-800 @break
+                                        @case('INFO') bg-blue-100 text-blue-800 @break
+                                        @case('WARNING') bg-yellow-100 text-yellow-800 @break
+                                        @case('ERROR') bg-red-100 text-red-800 @break
+                                        @case('CRITICAL') bg-pink-100 text-pink-800 @break
+                                        @default bg-gray-100 text-gray-800 @break
+                                    @endswitch
+                                ">
+                                    {{ $log->status }}
+                                </span>
+                            </dd>
+                        </div>
+                        @if($log->duration_seconds !== null)
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('Duração (segundos)') }}</dt>
+                            <dd class="text-gray-900 dark:text-gray-100">{{ $log->duration_seconds }}s</dd>
+                        </div>
+                        @endif
+                    </dl>
+                </div>
+
+                <div class="md:col-span-2">
+                    <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">{{ __('Mensagem') }}</h3>
+                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-gray-700 p-3 rounded-md whitespace-pre-wrap">{{ $log->message }}</p>
+
+                    @if($log->valve)
+                    <h3 class="mt-4 text-lg font-medium text-gray-900 dark:text-gray-100">{{ __('Válvula Associada') }}</h3>
+                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                        <a href="{{ route('admin.valves.show', $log->valve) }}" class="text-blue-600 hover:text-blue-800">
+                            {{ $log->valve->name }} (Nº {{ $log->valve->valve_number }})
+                        </a>
+                    </p>
+                    @endif
+
+                    @if($log->schedule)
+                    <h3 class="mt-4 text-lg font-medium text-gray-900 dark:text-gray-100">{{ __('Agendamento Associado') }}</h3>
+                     <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                        <a href="{{ route('admin.schedules.edit', $log->schedule) }}" class="text-blue-600 hover:text-blue-800">
+                            {{ $log->schedule->name }}
+                        </a>
+                    </p>
+                    @endif
+
+                    @if($log->user)
+                    <h3 class="mt-4 text-lg font-medium text-gray-900 dark:text-gray-100">{{ __('Utilizador Web Associado') }}</h3>
+                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                        <a href="{{ route('admin.users.show', $log->user) }}" class="text-blue-600 hover:text-blue-800">
+                            {{ $log->user->name }} ({{ $log->user->email }})
+                        </a>
+                    </p>
+                    @endif
+
+                    @if($log->telegramUser)
+                    <h3 class="mt-4 text-lg font-medium text-gray-900 dark:text-gray-100">{{ __('Utilizador Telegram Associado') }}</h3>
+                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                        <a href="{{ route('admin.telegram-users.edit', $log->telegramUser) }}" class="text-blue-600 hover:text-blue-800">
+                            {{ $log->telegramUser->first_name }} {{ $log->telegramUser->telegram_username ? '(@' . $log->telegramUser->telegram_username . ')' : '' }} (Chat ID: {{ $log->telegramUser->telegram_chat_id }})
+                        </a>
+                    </p>
+                    @endif
+                </div>
+            </div>
+
+            @if ($log->details)
+            <div class="mt-6">
+                <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">{{ __('Detalhes Adicionais (JSON)') }}</h3>
+                <pre class="mt-2 p-3 bg-gray-50 dark:bg-gray-900 text-sm text-gray-800 dark:text-gray-200 rounded-md overflow-x-auto"><code class="language-json">{{ json_encode($log->details, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) }}</code></pre>
+            </div>
+            @endif
+
+
+            <div class="mt-8 flex items-center justify-start">
+                <a href="{{ route('admin.operation-logs.index') }}" class="inline-flex items-center px-4 py-2 bg-gray-200 dark:bg-gray-600 border border-transparent rounded-md font-semibold text-xs text-gray-700 dark:text-gray-100 uppercase tracking-widest hover:bg-gray-300 dark:hover:bg-gray-500 focus:outline-none focus:border-gray-400 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                    {{ __('Voltar à Lista de Logs') }}
+                </a>
+            </div>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/schedules/create.blade.php
+++ b/resources/views/admin/schedules/create.blade.php
@@ -1,0 +1,89 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Adicionar Novo Agendamento') }}
+        </h2>
+    </x-slot>
+
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-6">
+            <form action="{{ route('admin.schedules.store') }}" method="POST">
+                @csrf
+                @php
+                    $daysOfWeek = ['Domingo', 'Segunda', 'Terça', 'Quarta', 'Quinta', 'Sexta', 'Sábado'];
+                @endphp
+
+                <!-- Nome do Agendamento -->
+                <div class="mb-4">
+                    <label for="name" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Nome do Agendamento') }}</label>
+                    <input type="text" name="name" id="name" value="{{ old('name', 'Rega Semanal Principal') }}"
+                           class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('name') border-red-500 @enderror"
+                           required>
+                    @error('name')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Dia da Semana -->
+                <div class="mb-4">
+                    <label for="day_of_week" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Dia da Semana') }}</label>
+                    <select name="day_of_week" id="day_of_week"
+                            class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('day_of_week') border-red-500 @enderror"
+                            required>
+                        @foreach ($daysOfWeek as $index => $dayName)
+                            <option value="{{ $index }}" {{ old('day_of_week', 5) == $index ? 'selected' : '' }}>{{ $dayName }}</option>
+                        @endforeach
+                    </select>
+                    @error('day_of_week')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Hora de Início -->
+                <div class="mb-4">
+                    <label for="start_time" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Hora de Início (HH:MM)') }}</label>
+                    <input type="time" name="start_time" id="start_time" value="{{ old('start_time', '10:00') }}"
+                           class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('start_time') border-red-500 @enderror"
+                           required>
+                    @error('start_time')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Duração por Válvula -->
+                <div class="mb-4">
+                    <label for="per_valve_duration_minutes" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Duração por Válvula (minutos)') }}</label>
+                    <input type="number" name="per_valve_duration_minutes" id="per_valve_duration_minutes" value="{{ old('per_valve_duration_minutes', 5) }}"
+                           class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('per_valve_duration_minutes') border-red-500 @enderror"
+                           required min="1">
+                    @error('per_valve_duration_minutes')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Ativo/Inativo -->
+                <div class="mb-6">
+                    <label for="is_enabled" class="flex items-center">
+                        <input type="checkbox" name="is_enabled" id="is_enabled" value="1" {{ old('is_enabled', true) ? 'checked' : '' }}
+                               class="rounded border-gray-300 dark:border-gray-600 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-700">
+                        <span class="ml-2 text-sm text-gray-600 dark:text-gray-300">{{ __('Ativar este agendamento') }}</span>
+                    </label>
+                     @error('is_enabled')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+
+                <!-- Botões de Ação -->
+                <div class="flex items-center justify-end space-x-4">
+                    <a href="{{ route('admin.schedules.index') }}" class="inline-flex items-center px-4 py-2 bg-gray-200 dark:bg-gray-600 border border-transparent rounded-md font-semibold text-xs text-gray-700 dark:text-gray-100 uppercase tracking-widest hover:bg-gray-300 dark:hover:bg-gray-500 focus:outline-none focus:border-gray-400 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                        {{ __('Cancelar') }}
+                    </a>
+                    <button type="submit" class="inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-500 active:bg-blue-700 focus:outline-none focus:border-blue-700 focus:ring ring-blue-300 disabled:opacity-25 transition ease-in-out duration-150">
+                        {{ __('Guardar Agendamento') }}
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/schedules/edit.blade.php
+++ b/resources/views/admin/schedules/edit.blade.php
@@ -1,0 +1,89 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Editar Agendamento') }}: {{ $schedule->name }}
+        </h2>
+    </x-slot>
+
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-6">
+            <form action="{{ route('admin.schedules.update', $schedule->id) }}" method="POST">
+                @csrf
+                @method('PUT')
+                @php
+                    $daysOfWeek = ['Domingo', 'Segunda', 'Terça', 'Quarta', 'Quinta', 'Sexta', 'Sábado'];
+                @endphp
+
+                <!-- Nome do Agendamento -->
+                <div class="mb-4">
+                    <label for="name" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Nome do Agendamento') }}</label>
+                    <input type="text" name="name" id="name" value="{{ old('name', $schedule->name) }}"
+                           class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('name') border-red-500 @enderror"
+                           required>
+                    @error('name')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Dia da Semana -->
+                <div class="mb-4">
+                    <label for="day_of_week" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Dia da Semana') }}</label>
+                    <select name="day_of_week" id="day_of_week"
+                            class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('day_of_week') border-red-500 @enderror"
+                            required>
+                        @foreach ($daysOfWeek as $index => $dayName)
+                            <option value="{{ $index }}" {{ old('day_of_week', $schedule->day_of_week) == $index ? 'selected' : '' }}>{{ $dayName }}</option>
+                        @endforeach
+                    </select>
+                    @error('day_of_week')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Hora de Início -->
+                <div class="mb-4">
+                    <label for="start_time" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Hora de Início (HH:MM)') }}</label>
+                    <input type="time" name="start_time" id="start_time" value="{{ old('start_time', \Carbon\Carbon::parse($schedule->start_time)->format('H:i')) }}"
+                           class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('start_time') border-red-500 @enderror"
+                           required>
+                    @error('start_time')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Duração por Válvula -->
+                <div class="mb-4">
+                    <label for="per_valve_duration_minutes" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Duração por Válvula (minutos)') }}</label>
+                    <input type="number" name="per_valve_duration_minutes" id="per_valve_duration_minutes" value="{{ old('per_valve_duration_minutes', $schedule->per_valve_duration_minutes) }}"
+                           class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('per_valve_duration_minutes') border-red-500 @enderror"
+                           required min="1">
+                    @error('per_valve_duration_minutes')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Ativo/Inativo -->
+                <div class="mb-6">
+                    <label for="is_enabled" class="flex items-center">
+                        <input type="checkbox" name="is_enabled" id="is_enabled" value="1" {{ old('is_enabled', $schedule->is_enabled) ? 'checked' : '' }}
+                               class="rounded border-gray-300 dark:border-gray-600 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-700">
+                        <span class="ml-2 text-sm text-gray-600 dark:text-gray-300">{{ __('Ativar este agendamento') }}</span>
+                    </label>
+                     @error('is_enabled')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Botões de Ação -->
+                <div class="flex items-center justify-end space-x-4">
+                    <a href="{{ route('admin.schedules.index') }}" class="inline-flex items-center px-4 py-2 bg-gray-200 dark:bg-gray-600 border border-transparent rounded-md font-semibold text-xs text-gray-700 dark:text-gray-100 uppercase tracking-widest hover:bg-gray-300 dark:hover:bg-gray-500 focus:outline-none focus:border-gray-400 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                        {{ __('Cancelar') }}
+                    </a>
+                    <button type="submit" class="inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-500 active:bg-blue-700 focus:outline-none focus:border-blue-700 focus:ring ring-blue-300 disabled:opacity-25 transition ease-in-out duration-150">
+                        {{ __('Atualizar Agendamento') }}
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/schedules/index.blade.php
+++ b/resources/views/admin/schedules/index.blade.php
@@ -1,0 +1,104 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Gestão de Agendamentos') }}
+        </h2>
+    </x-slot>
+
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+
+        <div class="mb-4 text-right">
+            <a href="{{ route('admin.schedules.create') }}" class="inline-flex items-center px-4 py-2 bg-green-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-green-500 active:bg-green-700 focus:outline-none focus:border-green-700 focus:ring ring-green-300 disabled:opacity-25 transition ease-in-out duration-150">
+                {{ __('Novo Agendamento') }}
+            </a>
+        </div>
+
+        @if (session('success'))
+            <div class="mb-4 p-4 bg-green-100 text-green-700 border border-green-300 rounded-md">
+                {{ session('success') }}
+            </div>
+        @endif
+        @if (session('error'))
+            <div class="mb-4 p-4 bg-red-100 text-red-700 border border-red-300 rounded-md">
+                {{ session('error') }}
+            </div>
+        @endif
+
+        <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg overflow-hidden">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <thead class="bg-gray-50 dark:bg-gray-700">
+                    <tr>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Nome') }}
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Dia da Semana') }}
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Hora Início') }}
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Duração/Válvula (min)') }}
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Ativo') }}
+                        </th>
+                        <th scope="col" class="relative px-6 py-3">
+                            <span class="sr-only">{{ __('Ações') }}</span>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                    @php
+                        $daysOfWeek = ['Domingo', 'Segunda', 'Terça', 'Quarta', 'Quinta', 'Sexta', 'Sábado'];
+                    @endphp
+                    @forelse ($schedules as $schedule)
+                        <tr>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">
+                                {{ $schedule->name }}
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                {{ $daysOfWeek[$schedule->day_of_week] ?? 'Inválido' }}
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                {{ \Carbon\Carbon::parse($schedule->start_time)->format('H:i') }}
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                {{ $schedule->per_valve_duration_minutes }}
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm">
+                                @if ($schedule->is_enabled)
+                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                                        {{ __('Sim') }}
+                                    </span>
+                                @else
+                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">
+                                        {{ __('Não') }}
+                                    </span>
+                                @endif
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                {{-- <a href="{{ route('admin.schedules.show', $schedule) }}" class="text-blue-600 hover:text-blue-900 dark:text-blue-400 dark:hover:text-blue-200 mr-2">{{ __('Ver') }}</a> --}}
+                                <a href="{{ route('admin.schedules.edit', $schedule) }}" class="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-200 mr-2">{{ __('Editar') }}</a>
+                                <form action="{{ route('admin.schedules.destroy', $schedule) }}" method="POST" class="inline-block" onsubmit="return confirm('{{ __('Tem a certeza que deseja eliminar este agendamento?') }}');">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-200">{{ __('Eliminar') }}</button>
+                                </form>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="6" class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300 text-center">
+                                {{ __('Nenhum agendamento encontrado.') }}
+                            </td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+        <div class="mt-4">
+            {{ $schedules->links() }}
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/telegram_users/edit.blade.php
+++ b/resources/views/admin/telegram_users/edit.blade.php
@@ -1,0 +1,102 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Gerir Autorização do Utilizador Telegram') }}: {{ $telegramUser->telegram_username ? '@' . $telegramUser->telegram_username : $telegramUser->telegram_chat_id }}
+        </h2>
+    </x-slot>
+
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-6">
+            <form action="{{ route('admin.telegram-users.update', $telegramUser->id) }}" method="POST">
+                @csrf
+                @method('PUT')
+
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+                    <div>
+                        <p class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Chat ID Telegram') }}</p>
+                        <p class="mt-1 text-lg text-gray-900 dark:text-gray-100">{{ $telegramUser->telegram_chat_id }}</p>
+                    </div>
+                    <div>
+                        <p class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Username Telegram') }}</p>
+                        <p class="mt-1 text-lg text-gray-900 dark:text-gray-100">{{ $telegramUser->telegram_username ? '@' . $telegramUser->telegram_username : '-' }}</p>
+                    </div>
+                    <div>
+                        <p class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Nome Telegram') }}</p>
+                        <p class="mt-1 text-lg text-gray-900 dark:text-gray-100">{{ $telegramUser->first_name }} {{ $telegramUser->last_name }}</p>
+                    </div>
+                     <div>
+                        <p class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Registado em (Bot)') }}</p>
+                        <p class="mt-1 text-lg text-gray-900 dark:text-gray-100">{{ $telegramUser->created_at->format('d/m/Y H:i') }}</p>
+                    </div>
+                </div>
+
+                <!-- Utilizador Web Vinculado -->
+                <div class="mb-4">
+                    <label for="user_id" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Vincular a Utilizador Web (Opcional)') }}</label>
+                    <select name="user_id" id="user_id"
+                            class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('user_id') border-red-500 @enderror">
+                        <option value="">{{ __('-- Nenhum --') }}</option>
+                        @foreach ($webUsers as $webUser)
+                            <option value="{{ $webUser->id }}" {{ old('user_id', $telegramUser->user_id) == $webUser->id ? 'selected' : '' }}>
+                                {{ $webUser->name }} ({{ $webUser->email }})
+                            </option>
+                        @endforeach
+                    </select>
+                    @error('user_id')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Autorizado -->
+                <div class="mb-4">
+                    <label for="is_authorized" class="flex items-center">
+                        <input type="hidden" name="is_authorized" value="0"> <!-- Valor default se checkbox não for marcado -->
+                        <input type="checkbox" name="is_authorized" id="is_authorized" value="1" {{ old('is_authorized', $telegramUser->is_authorized) ? 'checked' : '' }}
+                               class="rounded border-gray-300 dark:border-gray-600 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-700">
+                        <span class="ml-2 text-sm text-gray-600 dark:text-gray-300">{{ __('Autorizar este utilizador a interagir com o bot') }}</span>
+                    </label>
+                     @error('is_authorized')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Nível de Autorização Telegram -->
+                <div class="mb-4">
+                    <label for="authorization_level" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Nível de Autorização para Comandos Telegram') }}</label>
+                    <select name="authorization_level" id="authorization_level"
+                            class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('authorization_level') border-red-500 @enderror">
+                        <option value="">{{ __('-- Nenhum --') }}</option>
+                        <option value="user" {{ old('authorization_level', $telegramUser->authorization_level) == 'user' ? 'selected' : '' }}>{{ __('Utilizador (comandos básicos)') }}</option>
+                        <option value="admin" {{ old('authorization_level', $telegramUser->authorization_level) == 'admin' ? 'selected' : '' }}>{{ __('Administrador (todos os comandos)') }}</option>
+                    </select>
+                    @error('authorization_level')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Receber Notificações -->
+                 <div class="mb-6">
+                    <label for="receive_notifications" class="flex items-center">
+                        <input type="hidden" name="receive_notifications" value="0">
+                        <input type="checkbox" name="receive_notifications" id="receive_notifications" value="1" {{ old('receive_notifications', $telegramUser->receive_notifications) ? 'checked' : '' }}
+                               class="rounded border-gray-300 dark:border-gray-600 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-700">
+                        <span class="ml-2 text-sm text-gray-600 dark:text-gray-300">{{ __('Permitir que este utilizador receba notificações do bot') }}</span>
+                    </label>
+                     @error('receive_notifications')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Botões de Ação -->
+                <div class="flex items-center justify-end space-x-4">
+                    <a href="{{ route('admin.telegram-users.index') }}" class="inline-flex items-center px-4 py-2 bg-gray-200 dark:bg-gray-600 border border-transparent rounded-md font-semibold text-xs text-gray-700 dark:text-gray-100 uppercase tracking-widest hover:bg-gray-300 dark:hover:bg-gray-500 focus:outline-none focus:border-gray-400 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                        {{ __('Cancelar') }}
+                    </a>
+                    <button type="submit" class="inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-500 active:bg-blue-700 focus:outline-none focus:border-blue-700 focus:ring ring-blue-300 disabled:opacity-25 transition ease-in-out duration-150">
+                        {{ __('Guardar Alterações') }}
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/telegram_users/index.blade.php
+++ b/resources/views/admin/telegram_users/index.blade.php
@@ -1,0 +1,116 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Gestão de Utilizadores do Telegram') }}
+        </h2>
+    </x-slot>
+
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+
+        @if (session('success'))
+            <div class="mb-4 p-4 bg-green-100 text-green-700 border border-green-300 rounded-md">
+                {{ session('success') }}
+            </div>
+        @endif
+        @if (session('error'))
+            <div class="mb-4 p-4 bg-red-100 text-red-700 border border-red-300 rounded-md">
+                {{ session('error') }}
+            </div>
+        @endif
+
+        <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg overflow-hidden">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <thead class="bg-gray-50 dark:bg-gray-700">
+                    <tr>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Chat ID') }}
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Username Telegram') }}
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Nome') }}
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Utilizador Web Vinculado') }}
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Autorizado') }}
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Nível Telegram') }}
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Notificações') }}
+                        </th>
+                        <th scope="col" class="relative px-6 py-3">
+                            <span class="sr-only">{{ __('Ações') }}</span>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                    @forelse ($telegramUsers as $tgUser)
+                        <tr>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">
+                                {{ $tgUser->telegram_chat_id }}
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                {{ $tgUser->telegram_username ? '@' . $tgUser->telegram_username : '-' }}
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                {{ $tgUser->first_name }} {{ $tgUser->last_name }}
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                @if ($tgUser->user)
+                                    <a href="{{ route('admin.users.show', $tgUser->user) }}" class="text-blue-600 hover:text-blue-900">
+                                        {{ $tgUser->user->name }} (ID: {{ $tgUser->user_id }})
+                                    </a>
+                                @else
+                                    -
+                                @endif
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm">
+                                @if ($tgUser->is_authorized)
+                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                                        {{ __('Sim') }}
+                                    </span>
+                                @else
+                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">
+                                        {{ __('Não') }}
+                                    </span>
+                                @endif
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                {{ $tgUser->authorization_level ? ucfirst($tgUser->authorization_level) : '-' }}
+                            </td>
+                             <td class="px-6 py-4 whitespace-nowrap text-sm">
+                                @if ($tgUser->receive_notifications)
+                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                                        {{ __('Sim') }}
+                                    </span>
+                                @else
+                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">
+                                        {{ __('Não') }}
+                                    </span>
+                                @endif
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                <a href="{{ route('admin.telegram-users.edit', $tgUser) }}" class="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-200">{{ __('Gerir Autorização') }}</a>
+                                {{-- Não haverá delete aqui, pois o registo é criado quando o user interage com o bot --}}
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="8" class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300 text-center">
+                                {{ __('Nenhum utilizador do Telegram encontrado.') }}
+                            </td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+        <div class="mt-4">
+            {{ $telegramUsers->links() }}
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/users/create.blade.php
+++ b/resources/views/admin/users/create.blade.php
@@ -1,0 +1,80 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Adicionar Novo Utilizador') }}
+        </h2>
+    </x-slot>
+
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-6">
+            <form action="{{ route('admin.users.store') }}" method="POST">
+                @csrf
+
+                <!-- Nome -->
+                <div class="mb-4">
+                    <label for="name" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Nome Completo') }}</label>
+                    <input type="text" name="name" id="name" value="{{ old('name') }}"
+                           class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('name') border-red-500 @enderror"
+                           required autofocus>
+                    @error('name')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Email -->
+                <div class="mb-4">
+                    <label for="email" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Endereço de Email') }}</label>
+                    <input type="email" name="email" id="email" value="{{ old('email') }}"
+                           class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('email') border-red-500 @enderror"
+                           required>
+                    @error('email')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Senha (Password) -->
+                <div class="mb-4">
+                    <label for="password" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Senha') }}</label>
+                    <input type="password" name="password" id="password"
+                           class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('password') border-red-500 @enderror"
+                           required>
+                    @error('password')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Confirmação da Senha -->
+                <div class="mb-4">
+                    <label for="password_confirmation" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Confirmar Senha') }}</label>
+                    <input type="password" name="password_confirmation" id="password_confirmation"
+                           class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200"
+                           required>
+                </div>
+
+                <!-- Papel (Role) -->
+                <div class="mb-6">
+                    <label for="role" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Papel (Role)') }}</label>
+                    <select name="role" id="role"
+                            class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('role') border-red-500 @enderror"
+                            required>
+                        <option value="user" {{ old('role') == 'user' ? 'selected' : '' }}>{{ __('Utilizador') }}</option>
+                        <option value="admin" {{ old('role') == 'admin' ? 'selected' : '' }}>{{ __('Administrador') }}</option>
+                    </select>
+                    @error('role')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Botões de Ação -->
+                <div class="flex items-center justify-end space-x-4">
+                    <a href="{{ route('admin.users.index') }}" class="inline-flex items-center px-4 py-2 bg-gray-200 dark:bg-gray-600 border border-transparent rounded-md font-semibold text-xs text-gray-700 dark:text-gray-100 uppercase tracking-widest hover:bg-gray-300 dark:hover:bg-gray-500 focus:outline-none focus:border-gray-400 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                        {{ __('Cancelar') }}
+                    </a>
+                    <button type="submit" class="inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-500 active:bg-blue-700 focus:outline-none focus:border-blue-700 focus:ring ring-blue-300 disabled:opacity-25 transition ease-in-out duration-150">
+                        {{ __('Guardar Utilizador') }}
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -1,0 +1,83 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Editar Utilizador') }}: {{ $user->name }}
+        </h2>
+    </x-slot>
+
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-6">
+            <form action="{{ route('admin.users.update', $user->id) }}" method="POST">
+                @csrf
+                @method('PUT')
+
+                <!-- Nome -->
+                <div class="mb-4">
+                    <label for="name" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Nome Completo') }}</label>
+                    <input type="text" name="name" id="name" value="{{ old('name', $user->name) }}"
+                           class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('name') border-red-500 @enderror"
+                           required autofocus>
+                    @error('name')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Email -->
+                <div class="mb-4">
+                    <label for="email" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Endereço de Email') }}</label>
+                    <input type="email" name="email" id="email" value="{{ old('email', $user->email) }}"
+                           class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('email') border-red-500 @enderror"
+                           required>
+                    @error('email')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Senha (Password) - Opcional na edição -->
+                <div class="mb-4">
+                    <label for="password" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Nova Senha (Opcional - deixe em branco para não alterar)') }}</label>
+                    <input type="password" name="password" id="password"
+                           class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('password') border-red-500 @enderror">
+                    @error('password')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Confirmação da Senha (Opcional) -->
+                <div class="mb-4">
+                    <label for="password_confirmation" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Confirmar Nova Senha') }}</label>
+                    <input type="password" name="password_confirmation" id="password_confirmation"
+                           class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200">
+                </div>
+
+                <!-- Papel (Role) -->
+                <div class="mb-6">
+                    <label for="role" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Papel (Role)') }}</label>
+                    <select name="role" id="role"
+                            class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('role') border-red-500 @enderror"
+                            required {{ Auth::id() === $user->id ? 'disabled' : '' }}> {{-- Impedir admin de mudar o próprio papel aqui --}}
+                        <option value="user" {{ old('role', $user->role) == 'user' ? 'selected' : '' }}>{{ __('Utilizador') }}</option>
+                        <option value="admin" {{ old('role', $user->role) == 'admin' ? 'selected' : '' }}>{{ __('Administrador') }}</option>
+                    </select>
+                    @if (Auth::id() === $user->id)
+                        <input type="hidden" name="role" value="{{ $user->role }}" /> {{-- Enviar o papel atual se estiver desabilitado --}}
+                        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ __('Não pode alterar o seu próprio papel.') }}</p>
+                    @endif
+                    @error('role')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Botões de Ação -->
+                <div class="flex items-center justify-end space-x-4">
+                    <a href="{{ route('admin.users.index') }}" class="inline-flex items-center px-4 py-2 bg-gray-200 dark:bg-gray-600 border border-transparent rounded-md font-semibold text-xs text-gray-700 dark:text-gray-100 uppercase tracking-widest hover:bg-gray-300 dark:hover:bg-gray-500 focus:outline-none focus:border-gray-400 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                        {{ __('Cancelar') }}
+                    </a>
+                    <button type="submit" class="inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-500 active:bg-blue-700 focus:outline-none focus:border-blue-700 focus:ring ring-blue-300 disabled:opacity-25 transition ease-in-out duration-150">
+                        {{ __('Atualizar Utilizador') }}
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -1,0 +1,112 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Gestão de Utilizadores') }}
+        </h2>
+    </x-slot>
+
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+
+        <div class="mb-4 text-right">
+            <a href="{{ route('admin.users.create') }}" class="inline-flex items-center px-4 py-2 bg-green-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-green-500 active:bg-green-700 focus:outline-none focus:border-green-700 focus:ring ring-green-300 disabled:opacity-25 transition ease-in-out duration-150">
+                {{ __('Novo Utilizador') }}
+            </a>
+        </div>
+
+        @if (session('success'))
+            <div class="mb-4 p-4 bg-green-100 text-green-700 border border-green-300 rounded-md">
+                {{ session('success') }}
+            </div>
+        @endif
+        @if (session('error'))
+            <div class="mb-4 p-4 bg-red-100 text-red-700 border border-red-300 rounded-md">
+                {{ session('error') }}
+            </div>
+        @endif
+
+        <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg overflow-hidden">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <thead class="bg-gray-50 dark:bg-gray-700">
+                    <tr>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('ID') }}
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Nome') }}
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Email') }}
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Papel (Role)') }}
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Email Verificado') }}
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            {{ __('Registado em') }}
+                        </th>
+                        <th scope="col" class="relative px-6 py-3">
+                            <span class="sr-only">{{ __('Ações') }}</span>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                    @forelse ($users as $user)
+                        <tr>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">
+                                {{ $user->id }}
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                {{ $user->name }}
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                {{ $user->email }}
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full
+                                    {{ $user->role === 'admin' ? 'bg-red-100 text-red-800' : 'bg-blue-100 text-blue-800' }}">
+                                    {{ ucfirst($user->role) }}
+                                </span>
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm">
+                                @if ($user->email_verified_at)
+                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                                        {{ __('Sim') }}
+                                    </span>
+                                @else
+                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
+                                        {{ __('Não') }}
+                                    </span>
+                                @endif
+                            </td>
+                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                {{ $user->created_at->format('d/m/Y H:i') }}
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                <a href="{{ route('admin.users.show', $user) }}" class="text-blue-600 hover:text-blue-900 dark:text-blue-400 dark:hover:text-blue-200 mr-2">{{ __('Ver') }}</a>
+                                <a href="{{ route('admin.users.edit', $user) }}" class="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-200 mr-2">{{ __('Editar') }}</a>
+                                @if (Auth::id() !== $user->id) {{-- Não permitir auto-eliminação --}}
+                                    <form action="{{ route('admin.users.destroy', $user) }}" method="POST" class="inline-block" onsubmit="return confirm('{{ __('Tem a certeza que deseja eliminar este utilizador?') }}');">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-200">{{ __('Eliminar') }}</button>
+                                    </form>
+                                @endif
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="7" class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300 text-center">
+                                {{ __('Nenhum utilizador encontrado.') }}
+                            </td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+        <div class="mt-4">
+            {{ $users->links() }}
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/users/show.blade.php
+++ b/resources/views/admin/users/show.blade.php
@@ -1,0 +1,64 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Detalhes do Utilizador') }}: {{ $user->name }}
+        </h2>
+    </x-slot>
+
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-6">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div>
+                    <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">{{ __('Informações do Utilizador') }}</h3>
+                    <dl class="mt-2 divide-y divide-gray-200 dark:divide-gray-700">
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('ID') }}</dt>
+                            <dd class="text-gray-900 dark:text-gray-100">{{ $user->id }}</dd>
+                        </div>
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('Nome') }}</dt>
+                            <dd class="text-gray-900 dark:text-gray-100">{{ $user->name }}</dd>
+                        </div>
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('Email') }}</dt>
+                            <dd class="text-gray-900 dark:text-gray-100">{{ $user->email }}</dd>
+                        </div>
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('Papel (Role)') }}</dt>
+                            <dd class="text-gray-900 dark:text-gray-100">
+                                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full
+                                    {{ $user->role === 'admin' ? 'bg-red-100 text-red-800' : 'bg-blue-100 text-blue-800' }}">
+                                    {{ ucfirst($user->role) }}
+                                </span>
+                            </dd>
+                        </div>
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('Email Verificado em') }}</dt>
+                            <dd class="text-gray-900 dark:text-gray-100">{{ $user->email_verified_at ? $user->email_verified_at->format('d/m/Y H:i:s') : 'Não verificado' }}</dd>
+                        </div>
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('Registado em') }}</dt>
+                            <dd class="text-gray-900 dark:text-gray-100">{{ $user->created_at->format('d/m/Y H:i:s') }}</dd>
+                        </div>
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('Atualizado em') }}</dt>
+                            <dd class="text-gray-900 dark:text-gray-100">{{ $user->updated_at->format('d/m/Y H:i:s') }}</dd>
+                        </div>
+                    </dl>
+                </div>
+
+                {{-- Pode adicionar mais secções aqui, como logs de atividade do utilizador, etc. --}}
+
+            </div>
+
+            <div class="mt-8 flex items-center justify-end space-x-4">
+                <a href="{{ route('admin.users.index') }}" class="inline-flex items-center px-4 py-2 bg-gray-200 dark:bg-gray-600 border border-transparent rounded-md font-semibold text-xs text-gray-700 dark:text-gray-100 uppercase tracking-widest hover:bg-gray-300 dark:hover:bg-gray-500 focus:outline-none focus:border-gray-400 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                    {{ __('Voltar à Lista') }}
+                </a>
+                <a href="{{ route('admin.users.edit', $user->id) }}" class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-500 active:bg-indigo-700 focus:outline-none focus:border-indigo-700 focus:ring ring-indigo-300 disabled:opacity-25 transition ease-in-out duration-150">
+                    {{ __('Editar Utilizador') }}
+                </a>
+            </div>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/valves/create.blade.php
+++ b/resources/views/admin/valves/create.blade.php
@@ -1,0 +1,68 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Adicionar Nova Válvula') }}
+        </h2>
+    </x-slot>
+
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-6">
+            <form action="{{ route('admin.valves.store') }}" method="POST">
+                @csrf
+
+                <!-- Nome da Válvula -->
+                <div class="mb-4">
+                    <label for="name" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Nome da Válvula') }}</label>
+                    <input type="text" name="name" id="name" value="{{ old('name') }}"
+                           class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('name') border-red-500 @enderror"
+                           required>
+                    @error('name')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Número da Válvula -->
+                <div class="mb-4">
+                    <label for="valve_number" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Número da Válvula (1-5)') }}</label>
+                    <input type="number" name="valve_number" id="valve_number" value="{{ old('valve_number') }}"
+                           class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('valve_number') border-red-500 @enderror"
+                           required min="1" max="5">
+                    @error('valve_number')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Pino ESP32 -->
+                <div class="mb-4">
+                    <label for="esp32_pin" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Pino GPIO no ESP32 (Opcional)') }}</label>
+                    <input type="number" name="esp32_pin" id="esp32_pin" value="{{ old('esp32_pin') }}"
+                           class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('esp32_pin') border-red-500 @enderror"
+                           min="0">
+                    @error('esp32_pin')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Descrição -->
+                <div class="mb-6">
+                    <label for="description" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Descrição (Opcional)') }}</label>
+                    <textarea name="description" id="description" rows="3"
+                              class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('description') border-red-500 @enderror">{{ old('description') }}</textarea>
+                    @error('description')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Botões de Ação -->
+                <div class="flex items-center justify-end space-x-4">
+                    <a href="{{ route('admin.valves.index') }}" class="inline-flex items-center px-4 py-2 bg-gray-200 dark:bg-gray-600 border border-transparent rounded-md font-semibold text-xs text-gray-700 dark:text-gray-100 uppercase tracking-widest hover:bg-gray-300 dark:hover:bg-gray-500 focus:outline-none focus:border-gray-400 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                        {{ __('Cancelar') }}
+                    </a>
+                    <button type="submit" class="inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-500 active:bg-blue-700 focus:outline-none focus:border-blue-700 focus:ring ring-blue-300 disabled:opacity-25 transition ease-in-out duration-150">
+                        {{ __('Guardar Válvula') }}
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/valves/edit.blade.php
+++ b/resources/views/admin/valves/edit.blade.php
@@ -1,0 +1,69 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Editar Válvula') }}: {{ $valve->name }}
+        </h2>
+    </x-slot>
+
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-6">
+            <form action="{{ route('admin.valves.update', $valve->id) }}" method="POST">
+                @csrf
+                @method('PUT') {{-- ou PATCH --}}
+
+                <!-- Nome da Válvula -->
+                <div class="mb-4">
+                    <label for="name" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Nome da Válvula') }}</label>
+                    <input type="text" name="name" id="name" value="{{ old('name', $valve->name) }}"
+                           class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('name') border-red-500 @enderror"
+                           required>
+                    @error('name')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Número da Válvula -->
+                <div class="mb-4">
+                    <label for="valve_number" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Número da Válvula (1-5)') }}</label>
+                    <input type="number" name="valve_number" id="valve_number" value="{{ old('valve_number', $valve->valve_number) }}"
+                           class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('valve_number') border-red-500 @enderror"
+                           required min="1" max="5">
+                    @error('valve_number')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Pino ESP32 -->
+                <div class="mb-4">
+                    <label for="esp32_pin" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Pino GPIO no ESP32 (Opcional)') }}</label>
+                    <input type="number" name="esp32_pin" id="esp32_pin" value="{{ old('esp32_pin', $valve->esp32_pin) }}"
+                           class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('esp32_pin') border-red-500 @enderror"
+                           min="0">
+                    @error('esp32_pin')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Descrição -->
+                <div class="mb-6">
+                    <label for="description" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Descrição (Opcional)') }}</label>
+                    <textarea name="description" id="description" rows="3"
+                              class="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200 @error('description') border-red-500 @enderror">{{ old('description', $valve->description) }}</textarea>
+                    @error('description')
+                        <p class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <!-- Botões de Ação -->
+                <div class="flex items-center justify-end space-x-4">
+                    <a href="{{ route('admin.valves.index') }}" class="inline-flex items-center px-4 py-2 bg-gray-200 dark:bg-gray-600 border border-transparent rounded-md font-semibold text-xs text-gray-700 dark:text-gray-100 uppercase tracking-widest hover:bg-gray-300 dark:hover:bg-gray-500 focus:outline-none focus:border-gray-400 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                        {{ __('Cancelar') }}
+                    </a>
+                    <button type="submit" class="inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-500 active:bg-blue-700 focus:outline-none focus:border-blue-700 focus:ring ring-blue-300 disabled:opacity-25 transition ease-in-out duration-150">
+                        {{ __('Atualizar Válvula') }}
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/valves/show.blade.php
+++ b/resources/views/admin/valves/show.blade.php
@@ -1,0 +1,85 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Detalhes da Válvula') }}: {{ $valve->name }}
+        </h2>
+    </x-slot>
+
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-6">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div>
+                    <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">{{ __('Informações da Válvula') }}</h3>
+                    <dl class="mt-2 divide-y divide-gray-200 dark:divide-gray-700">
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('ID') }}</dt>
+                            <dd class="text-gray-900 dark:text-gray-100">{{ $valve->id }}</dd>
+                        </div>
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('Nome') }}</dt>
+                            <dd class="text-gray-900 dark:text-gray-100">{{ $valve->name }}</dd>
+                        </div>
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('Número da Válvula') }}</dt>
+                            <dd class="text-gray-900 dark:text-gray-100">{{ $valve->valve_number }}</dd>
+                        </div>
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('Pino GPIO no ESP32') }}</dt>
+                            <dd class="text-gray-900 dark:text-gray-100">{{ $valve->esp32_pin ?? '-' }}</dd>
+                        </div>
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('Descrição') }}</dt>
+                            <dd class="text-gray-900 dark:text-gray-100 prose dark:prose-invert max-w-none">
+                                {{ $valve->description ?? '-' }}
+                            </dd>
+                        </div>
+                    </dl>
+                </div>
+                <div>
+                    <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">{{ __('Estado e Operação') }}</h3>
+                    <dl class="mt-2 divide-y divide-gray-200 dark:divide-gray-700">
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('Estado Atual') }}</dt>
+                            <dd>
+                                @if ($valve->current_state)
+                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                                        {{ __('Ligada') }}
+                                    </span>
+                                @else
+                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">
+                                        {{ __('Desligada') }}
+                                    </span>
+                                @endif
+                            </dd>
+                        </div>
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('Última Ativação') }}</dt>
+                            <dd class="text-gray-900 dark:text-gray-100">{{ $valve->last_activated_at ? $valve->last_activated_at->format('d/m/Y H:i:s') : 'Nunca ativada' }}</dd>
+                        </div>
+                         <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('Criada em') }}</dt>
+                            <dd class="text-gray-900 dark:text-gray-100">{{ $valve->created_at->format('d/m/Y H:i:s') }}</dd>
+                        </div>
+                        <div class="py-3 flex justify-between text-sm font-medium">
+                            <dt class="text-gray-500 dark:text-gray-400">{{ __('Atualizada em') }}</dt>
+                            <dd class="text-gray-900 dark:text-gray-100">{{ $valve->updated_at->format('d/m/Y H:i:s') }}</dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+
+            <div class="mt-8 flex items-center justify-end space-x-4">
+                <a href="{{ route('admin.valves.index') }}" class="inline-flex items-center px-4 py-2 bg-gray-200 dark:bg-gray-600 border border-transparent rounded-md font-semibold text-xs text-gray-700 dark:text-gray-100 uppercase tracking-widest hover:bg-gray-300 dark:hover:bg-gray-500 focus:outline-none focus:border-gray-400 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                    {{ __('Voltar à Lista') }}
+                </a>
+                <a href="{{ route('admin.valves.edit', $valve->id) }}" class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-500 active:bg-indigo-700 focus:outline-none focus:border-indigo-700 focus:ring ring-indigo-300 disabled:opacity-25 transition ease-in-out duration-150">
+                    {{ __('Editar Válvula') }}
+                </a>
+            </div>
+
+            {{-- Futuramente, poderia adicionar aqui uma secção com os últimos logs de operação desta válvula --}}
+            {{-- Ex: @include('admin.valves.partials.operation-logs-for-valve', ['logs' => $valve->operationLogs()->latest()->take(10)->get()]) --}}
+
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/components/admin/stat-card.blade.php
+++ b/resources/views/components/admin/stat-card.blade.php
@@ -1,0 +1,20 @@
+@props(['title', 'value', 'iconPath', 'iconClass' => 'text-gray-500'])
+
+<div class="bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6">
+    <div class="flex items-center">
+        <div class="p-3 rounded-full bg-opacity-20 {{
+            Str::contains($iconClass, 'blue') ? 'bg-blue-100 dark:bg-blue-900' :
+            (Str::contains($iconClass, 'green') ? 'bg-green-100 dark:bg-green-900' :
+            (Str::contains($iconClass, 'purple') ? 'bg-purple-100 dark:bg-purple-900' :
+            'bg-gray-100 dark:bg-gray-700'))
+        }}">
+            <svg class="h-8 w-8 {{ $iconClass }}" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="{{ $iconPath }}" />
+            </svg>
+        </div>
+        <div class="ml-4">
+            <p class="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase">{{ $title }}</p>
+            <p class="text-2xl font-semibold text-gray-900 dark:text-gray-100">{{ $value }}</p>
+        </div>
+    </div>
+</div>

--- a/resources/views/components/session-alert.blade.php
+++ b/resources/views/components/session-alert.blade.php
@@ -1,0 +1,11 @@
+@if ($successMessage)
+    <div {{ $attributes->merge(['class' => 'mb-4 p-4 bg-green-100 text-green-700 border border-green-300 rounded-md dark:bg-green-700 dark:text-green-100 dark:border-green-600']) }}>
+        {{ $successMessage }}
+    </div>
+@endif
+
+@if ($errorMessage)
+    <div {{ $attributes->merge(['class' => 'mb-4 p-4 bg-red-100 text-red-700 border border-red-300 rounded-md dark:bg-red-700 dark:text-red-100 dark:border-red-600']) }}>
+        {{ $errorMessage }}
+    </div>
+@endif

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,0 +1,90 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Painel de Controlo') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 dark:text-gray-100">
+                    {{ __("Bem-vindo(a) ao seu painel de controlo!") }}
+                </div>
+            </div>
+
+            <!-- Secção de Estado das Válvulas -->
+            <div class="mt-6 bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6">
+                <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+                    {{ __('Estado Atual das Válvulas') }}
+                </h3>
+                @if(isset($valvesStatus) && $valvesStatus->count() > 0)
+                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                        @foreach ($valvesStatus as $valve)
+                            <div class="p-4 rounded-md {{ $valve->current_state ? 'bg-green-100 dark:bg-green-700' : 'bg-red-100 dark:bg-red-700' }}">
+                                <div class="flex justify-between items-center">
+                                    <h4 class="font-semibold text-md {{ $valve->current_state ? 'text-green-800 dark:text-green-200' : 'text-red-800 dark:text-red-200' }}">
+                                        Válvula {{ $valve->valve_number }}: {{ $valve->name }}
+                                    </h4>
+                                    <span class="px-3 py-1 text-xs font-bold rounded-full {{ $valve->current_state ? 'bg-green-500 text-white' : 'bg-red-500 text-white' }}">
+                                        {{ $valve->current_state ? __('Ligada') : __('Desligada') }}
+                                    </span>
+                                </div>
+                                <p class="text-xs mt-1 {{ $valve->current_state ? 'text-green-600 dark:text-green-300' : 'text-red-600 dark:text-red-300' }}">
+                                    {{ __('Última ativação:') }} {{ $valve->last_activated_at ? \Carbon\Carbon::parse($valve->last_activated_at)->diffForHumans() : __('N/A') }}
+                                </p>
+                            </div>
+                        @endforeach
+                    </div>
+                @else
+                    <p class="text-gray-500 dark:text-gray-400">{{ __('Nenhuma válvula configurada ou estado indisponível.') }}</p>
+                @endif
+            </div>
+
+            <!-- Secção de Próximos Agendamentos -->
+            @if(isset($upcomingSchedulesProcessed) && count($upcomingSchedulesProcessed) > 0)
+                <div class="mt-6 bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6">
+                    @php $daysOfWeek = ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb']; @endphp
+                    <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+                        {{ __('Próximos Agendamentos Programados') }}
+                    </h3>
+                    <div class="space-y-3">
+                        @foreach ($upcomingSchedulesProcessed as $occurrence)
+                            <div class="p-3 bg-gray-50 dark:bg-gray-700 rounded-md">
+                                <p class="font-medium text-gray-800 dark:text-gray-200">{{ $occurrence['name'] }}</p>
+                                <p class="text-sm text-gray-600 dark:text-gray-300">
+                                    {{ $daysOfWeek[$occurrence['datetime']->dayOfWeek] }}, {{ $occurrence['datetime']->format('d/m/Y H:i') }}
+                                    ({{ __('Duração/Válvula:') }} {{ $occurrence['per_valve_duration_minutes'] }} {{ __('min') }})
+                                </p>
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+            @endif
+
+            <!-- Secção de Logs Recentes do Sistema -->
+            @if(isset($recentSystemLogs) && $recentSystemLogs->count() > 0)
+                <div class="mt-6 bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6">
+                    <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+                        {{ __('Últimas Atividades do Sistema') }}
+                    </h3>
+                    <ul class="space-y-2">
+                        @foreach($recentSystemLogs as $log)
+                        <li class="text-sm p-2 rounded bg-gray-50 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
+                            <strong class="font-medium">
+                                {{ \Carbon\Carbon::parse($log->logged_at)->format('d/m H:i') }}
+                                [{{$log->source}} - {{$log->status}}]:
+                            </strong>
+                            {{ Str::limit($log->message, 100) }}
+                            {{-- Se quiser link para detalhes (precisa de rota para user comum ver logs)
+                            <a href="#" class="text-blue-600 hover:underline ml-2">Detalhes</a>
+                            --}}
+                        </li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,16 +23,12 @@ Route::get('/', function () {
     return view('welcome'); // Página inicial pública
 });
 
-// Dashboard principal para utilizadores logados (Breeze default)
-// A view 'dashboard' é criada pelo Breeze
-Route::get('/dashboard', function () {
-    // Adicionar lógica para diferenciar dashboard de admin e user se necessário,
-    // ou redirecionar admin para /admin/dashboard
-    if (auth()->check() && auth()->user()->hasRole('admin')) {
-        // return redirect()->route('admin.dashboard'); // Descomentar quando a rota admin.dashboard existir
-    }
-    return view('dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+// Dashboard principal para utilizadores logados
+use App\Http{Controllers\UserDashboardController;
+
+Route::get('/dashboard', [UserDashboardController::class, 'index'])
+    ->middleware(['auth', 'verified'])
+    ->name('dashboard');
 
 // Rotas de Profile (Breeze default)
 Route::middleware('auth')->group(function () {


### PR DESCRIPTION
This commit includes the initial set of Blade views for the Laravel backend, focusing on the administration area and the common user dashboard.

Key additions:
- Admin Layout and Navigation: Created a main layout for the admin panel (`<x-admin-layout>`) and its navigation partial.
- CRUD Views for Admin:
  - Valves: index, create, edit, and show views.
  - Schedules: index, create, and edit views.
  - Users: index, create, edit, and show views.
  - Telegram Users: index and edit (for authorization management) views.
  - Operation Logs: index and show (with JSON detail view) views.
- Dashboards:
  - Admin Dashboard: View (`admin/dashboard.blade.php`) with summary cards, valve status, upcoming schedules, recent logs, and quick links. Corresponding `AdminDashboardController` fetches the data.
  - User Dashboard: Modified the default Breeze dashboard (`dashboard.blade.php`) to display valve status, upcoming schedules, and relevant system logs. Corresponding `UserDashboardController` fetches data and handles admin redirection.
- Reusable Blade Components:
  - `Admin.StatCard`: Component for displaying summary statistics cards on the admin dashboard.
  - `SessionAlert`: Component for consistently displaying session success and error messages.

These views provide a functional interface for managing and monitoring the irrigation system through the web panel. Further styling refinements and detailed testing in a local environment are the next steps for this frontend part.